### PR TITLE
Minor Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ jobs:
                   openai_api_key: ${{ secrets.OPENAI_API_KEY }}
                   github_token: ${{ secrets.GIT_TOKEN }}
                   github_pr_id: ${{ github.event.number }}
+                  openai_model: gpt-4o-mini
+                  files: "*.js, *ts, *.py, *.cpp, *.java"
 ```
 
 ### Optional: Pull Request template configuration

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ jobs:
             - uses: agogear/chatgpt-pr-review@0.0.13
               with:
                   openai_api_key: ${{ secrets.OPENAI_API_KEY }}
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  github_token: ${{ secrets.GIT_TOKEN }}
                   github_pr_id: ${{ github.event.number }}
 ```
 

--- a/action.yaml
+++ b/action.yaml
@@ -15,9 +15,9 @@ inputs:
     required: false
     default: "*"
   openai_model:
-    description: "GPT-3 model name."
+    description: "GPT-4 model name."
     required: false
-    default: "gpt-4o"
+    default: "gpt-4o-mini"
   openai_temperature:
     description: "Sampling temperature, [0, 1]. Higher values mean the model will take more risks when generating answers."
     required: false

--- a/action.yaml
+++ b/action.yaml
@@ -17,7 +17,7 @@ inputs:
   openai_model:
     description: "GPT-3 model name."
     required: false
-    default: "gpt-3.5-turbo"
+    default: "gpt-4o"
   openai_temperature:
     description: "Sampling temperature, [0, 1]. Higher values mean the model will take more risks when generating answers."
     required: false

--- a/main.py
+++ b/main.py
@@ -203,9 +203,9 @@ def main():
     )
     parser.add_argument(
         "--openai_model",
-        default="gpt-3.5-turbo",
-        help="GPT-3 model to use. Options: gpt-3.5-turbo, text-davinci-002, "
-        "text-babbage-001, text-curie-001, text-ada-001. Recommended: gpt-3.5-turbo",
+        default="gpt-4o-mini",
+        help="GPT-4 model to use. Options: gpt-4o-mini, text-davinci-002, "
+        "text-babbage-001, text-curie-001, text-ada-001. Recommended: gpt-4o-mini",
     )
     parser.add_argument(
         "--openai_temperature",


### PR DESCRIPTION
1. Change secrets.GITHUB_TOKEN to secrets.GIT_TOKEN as the token is not allowed to start with GITHUB_
2. Update default model to gpt-4o-mini across files to be cost efficient (cheaper than 3.5 turbo) 